### PR TITLE
install less and delete more

### DIFF
--- a/playgrounds/100.rootfs-ubuntu-24-04/Dockerfile
+++ b/playgrounds/100.rootfs-ubuntu-24-04/Dockerfile
@@ -20,7 +20,7 @@ set -eu
 apt-get update
 apt-get upgrade -y
 
-apt-get install -y \
+apt-get install -y --no-install-recommends \
   bash-completion \
   bzip2 \
   ca-certificates \
@@ -62,6 +62,9 @@ yes | unminimize
 # Doesn't seem to be needed and produces extra noise in journald.
 systemctl mask networkd-dispatcher.service
 
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
 rm -rf /etc/update-motd.d/*
 rm -f /.dockerenv
 
@@ -75,7 +78,7 @@ RUN <<EOF
 set -eu
 
 apt-get update
-apt-get install -y openssh-server
+apt-get install -y --no-install-recommends openssh-server
 
 echo "HostKey /etc/ssh/ssh_host_ed25519_key" >> /etc/ssh/sshd_config
 echo "AuthenticationMethods publickey" >> /etc/ssh/sshd_config
@@ -93,6 +96,9 @@ rm -f /etc/systemd/system/ssh.socket.d/addresses.conf
 systemctl enable ssh.service
 
 rm -f /etc/ssh/ssh_host_*
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
 EOF
 
 

--- a/playgrounds/scripts/get-code-server.sh
+++ b/playgrounds/scripts/get-code-server.sh
@@ -5,6 +5,8 @@ ln -s / $HOME/.rootfs
 
 curl -fsSL https://code-server.dev/install.sh | sh
 
+rm -f $HOME/.cache/code-server/code-server_*.deb
+
 mkdir -p $HOME/.local/share/code-server/User
 cat <<EOF > $HOME/.local/share/code-server/User/settings.json
 {


### PR DESCRIPTION
At the outset, I'll mention this investigation was aided by codex, so if there are alternate things/methods we could use to confirm this has no change in behavior, I will happily close this PR and do that instead. :saluting_face: 

Updates in this commit:
- Clean apt metadata after apt installs in `Dockerfile`.
- Remove the downloaded code-server `.deb` after install in `get-code-server.sh`.
- Install apt packages with `--no-install-recommends` in `Dockerfile`.

It looks like this cuts off around 181MB from the final image size.

The approach to validate that there was no change in behavior:

- Built a temporary variant using `apt-get install -y --no-install-recommends` for the two apt install blocks.
- Package list comparison (`dpkg-query -W` sorted, blank lines removed) between the baseline image and the `--no-install-recommends` variant showed no differences.
- Size delta from `--no-install-recommends` alone: ~42.6MB (~3.5%).

Rationale for no behavior change:
- Identical dpkg package sets mean the runtime and CLI surface is unchanged.
- Only the apt resolver behavior changed; it did not affect the final installed packages in this build.