### PR TITLE
feat: improve skill review scores + add Tessl CI workflow

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/content-samples/claude/skills/detect-local-content-folder/SKILL.md
+++ b/content-samples/claude/skills/detect-local-content-folder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: detect-local-content-folder
-description: Finds the local folder for a given content kind and name. Use before pulling or pushing content to determine the correct local directory.
+description: "Locates the local directory path for a challenge, tutorial, course, or skill-path by name. Resolves exact and hex-suffixed folder names. Use when finding a folder path, locating a content directory, or resolving where local content files are stored before pull or push operations."
 argument-hint: <kind> <name>
 user-invocable: false
 allowed-tools: Glob
@@ -11,10 +11,10 @@ Find the local folder for content of kind `$0` with name `$1`.
 ## Rules
 
 1. The local folder is always inside the **pluralized kind** subdirectory of the project root:
-   - `challenge` -> `challenges/`
-   - `tutorial` -> `tutorials/`
-   - `course` -> `courses/`
-   - `skill-path` -> `skill-paths/`
+   - `challenge` → `challenges/`
+   - `tutorial` → `tutorials/`
+   - `course` → `courses/`
+   - `skill-path` → `skill-paths/`
 
 2. The folder either:
    - Matches the name **exactly**: `<kind-plural>/$1/`
@@ -23,6 +23,8 @@ Find the local folder for content of kind `$0` with name `$1`.
 ## Steps
 
 1. Use Glob to search for `$0s/$1/index.md` (exact match).
+   Example: `Glob('challenges/docker-101/index.md')`
 2. If not found, use Glob to search for `$0s/$1-*/index.md` (suffix match).
+   Example: `Glob('challenges/docker-101-*/index.md')`
 3. If a match is found, return the folder path (without the `index.md` part).
 4. If no match is found, report that no local folder was detected.

--- a/content-samples/claude/skills/edit-remote-content/SKILL.md
+++ b/content-samples/claude/skills/edit-remote-content/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: edit-remote-content
-description: Pushes local content edits to the remote server. Supports pushing the entire directory or only specific changed files. Use after editing local content files to sync changes to the server.
+description: "Pushes local content edits for challenges, tutorials, courses, or skill-paths to the iximiuz Labs remote server via labctl. Supports uploading the entire directory or only specific changed files. Use when syncing edits, uploading changes, deploying content updates, or publishing modified markdown and assets to the server."
 argument-hint: <kind> <name>
 ---
 
@@ -21,3 +21,5 @@ Push local edits for content of kind `$0` with name `$1` to the remote server.
    ```sh
    labctl content push $0 $1 --dir <folder> --force
    ```
+
+3. **Verify the push** by checking the command exit code. A non-zero exit code indicates failure (e.g., network error, authentication issue, or missing local files).

--- a/content-samples/claude/skills/pull-content-source/SKILL.md
+++ b/content-samples/claude/skills/pull-content-source/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pull-content-source
-description: Pulls remote content source files to the local project directory. Use when you need to fetch or update local copies of content from the server.
+description: "Downloads remote challenge, tutorial, course, or skill-path source files from iximiuz Labs to the local project directory via labctl. Use when fetching content, syncing from the server, downloading latest source, or refreshing local copies of markdown and assets."
 argument-hint: <kind> <name>
 ---
 
@@ -20,4 +20,6 @@ Pull remote content of kind `$0` with name `$1` to the local project directory.
      labctl content pull $0 $1 --dir $0s/$1 --force
      ```
 
-The `--force` flag overwrites existing local files without confirmation.
+   The `--force` flag overwrites existing local files without confirmation.
+
+3. **Verify the pull** by checking the command exit code. A non-zero exit code indicates failure (e.g., network error, content not found, or authentication issue).

--- a/content-samples/claude/skills/push-content-source/SKILL.md
+++ b/content-samples/claude/skills/push-content-source/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: push-content-source
-description: Pushes local content source files to the remote server. Use when you need to publish content changes.
+description: "Uploads local challenge, tutorial, course, or skill-path source files to the iximiuz Labs remote server via labctl. Overwrites the remote version with local content. Use when publishing content, deploying changes, uploading source files, or pushing all local markdown and assets to the server."
 argument-hint: <kind> <name>
 ---
 
@@ -15,6 +15,11 @@ Push local content of kind `$0` with name `$1` to the remote server.
    labctl content push $0 $1 --dir <folder> --force
    ```
 
-   If no local folder was detected, report an error - cannot push content without local source files.
+   If no local folder was detected, report an error — cannot push content without local source files.
 
-The `--force` flag overwrites remote files with local ones without confirmation.
+   The `--force` flag overwrites remote files with local ones without confirmation.
+
+3. **Verify the push** by checking the command exit code. A non-zero exit code indicates failure:
+   - **Authentication error** → run `labctl auth login` to re-authenticate.
+   - **Network error** → retry the push command.
+   - **Missing local files** → verify the folder path from step 1 is correct.

--- a/content-samples/claude/skills/start-challenge/SKILL.md
+++ b/content-samples/claude/skills/start-challenge/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: start-challenge
-description: Starts a challenge playground session. Use when you need to launch a challenge for testing or solving.
+description: "Launches an iximiuz Labs challenge playground session using labctl, provisioning a sandboxed VM environment with pre-configured tools. Runs init tasks, then provides a playground ID for SSH access and command execution. Use when starting a challenge, launching a practice problem, beginning a hands-on exercise, or testing challenge content."
 argument-hint: <challenge-name>
 ---
 
-Start the challenge `$0`.
+Start the challenge `$0` (e.g., `docker-101-container-exec`).
 
-Run the following command in the background (it may block waiting for init tasks):
+Run the following command in the background — it blocks while init tasks provision the VM:
 
 ```sh
-labctl challenge start $0 --no-open --no-ssh
+labctl challenge start $0 --no-open --no-ssh &
 ```
 
-The `--no-open` flag prevents opening the browser.
-The `--no-ssh` flag prevents starting an interactive SSH session.
+- `--no-open` — prevents opening the browser.
+- `--no-ssh` — prevents starting an interactive SSH session.
 
-Since this command may take a long time (it waits for all init tasks to complete),
-run it in the background and immediately use the `list-running-playgrounds` skill
-to find the playground ID for further operations.
+Immediately use the `list-running-playgrounds` skill to find the playground ID for further operations (SSH, running commands, inspecting tasks).
+
+If the command fails or the playground does not appear in the running list, check `labctl` output for errors (e.g., authentication, challenge name not found).


### PR DESCRIPTION
Hey @iximiuz 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/e103f92a-2c31-403b-a40d-6c31da1b238b" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| detect-local-content-folder | 69% | 100% | +31% |
| edit-remote-content | 77% | 100% | +23% |
| pull-content-source | 77% | 100% | +23% |
| push-content-source | 77% | 100% | +23% |
| start-challenge | 70% | 94% | +24% |

This PR intentionally caps changes at five skills to keep it reviewable. The included workflow (below) will surface Tessl feedback on future `SKILL.md` changes so the rest of the library can improve incrementally.

<details>
<summary>Changes summary</summary>

**Description improvements (all 5 skills):**
- Expanded frontmatter descriptions with specific content types (challenges, tutorials, courses, skill-paths) and tool names (labctl, iximiuz Labs)
- Added natural trigger terms users would actually say (e.g., "find folder path", "sync edits", "upload changes", "download latest source", "launch a practice problem")
- Used quoted string format for descriptions instead of bare strings
- Improved specificity and distinctiveness to reduce skill conflict risk

**Content improvements:**
- **detect-local-content-folder**: Added concrete Glob pattern examples (`Glob('challenges/docker-101/index.md')`)
- **edit-remote-content / pull-content-source / push-content-source**: Added verification steps with exit code checking and common error recovery guidance
- **start-challenge**: Added concrete example challenge name, explicit `&` background syntax, and error handling guidance

</details>

## Tessl Skill Review GitHub Action

This PR also adds `.github/workflows/skill-review.yml` — a lightweight workflow that gives you automatic skill quality feedback on future PRs:

- **What runs:** On PRs that change `**/SKILL.md`, the workflow runs [`tesslio/skill-review`](https://github.com/tesslio/skill-review) and posts **one** comment with Tessl scores and feedback (updated on new pushes).
- **Zero extra accounts:** Contributors do **not** need a Tessl login — only the default `GITHUB_TOKEN` is used to post comments.
- **Non-blocking by default:** The check is feedback-only — no surprise red CI unless you add `fail-threshold`.
- **Not a build replacement:** This is review automation for skill markdown only, not a substitute for any build or transform pipeline.
- **Optional gate:** Add `with: fail-threshold: 70` later if you want PRs to fail on low scores.
- **Why only five skills here:** Keeps this PR reviewable. After merge, every PR that touches `SKILL.md` gets automatic review comments — the rest of the library improves incrementally.

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
