### PR TITLE
feat: added yay installation to archlinux baseimage

### DIFF
--- a/playgrounds/100.rootfs-archlinux/Dockerfile
+++ b/playgrounds/100.rootfs-archlinux/Dockerfile
@@ -121,3 +121,6 @@ RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/get-fzf.sh
 RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/customize-bashrc.sh
 RUN --mount=type=bind,source=scripts,target=/tmp/scripts USER=$LAB_USER /tmp/scripts/customize-git.sh
 RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/customize-vimrc.sh
+
+# System-wide user tools - built as $LAB_USER
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/get-yay.sh

--- a/playgrounds/scripts/get-yay.sh
+++ b/playgrounds/scripts/get-yay.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+DIR=$(mktemp -d)
+
+git clone --depth 1 https://aur.archlinux.org/yay-bin.git "${DIR}/yay"
+
+cd "${DIR}/yay"
+makepkg -si --noconfirm
+cd /
+
+rm -rf "${DIR}"


### PR DESCRIPTION
Dear @iximiuz,

I drafted this initial version of a PR to add yay (Yet another yogurt) as a pacman wrapper with AUR support to the archlinux base image. As a frequent archlinux playground user I would love to have access to a Arch User Repository (AUR) helper inside the playground that make the vast range of software available via the AUR more accessible.

I when with yay (quite biased as I use it on the majority of my Arch-based systems) as based on the votes in the AUR it seems to be one of the most popular options amongst the archlinux users.

First question: are you in general willing to at something like this to the base image? If so I'm happy to refine the PR until it meets your expectations.

So far I went with the MVP version: script-based installer that I kept as close to the already existing onces as possible. Downloading the AUR git repository that packages yay (maintained directly by the yay maintainer himself). Building and installing the yay pacman package to make the program available in the base image. The version of yay is currently also pointing to most recent available as the AUR package git repo is currently not tagged or anything.

Looking forward to hear what you think!