### PR TITLE
fix: load fzf autocompletion after bash_completion

### DIFF
--- a/playgrounds/scripts/customize-bashrc.sh
+++ b/playgrounds/scripts/customize-bashrc.sh
@@ -24,6 +24,8 @@ if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
     . /etc/bash_completion
 fi
 
+[ -f ~/.fzf.bash ] && source ~/.fzf.bash
+
 if type rg &> /dev/null; then
     export FZF_DEFAULT_COMMAND='rg --files'
     export FZF_DEFAULT_OPTS='-m --height 50% --border'

--- a/playgrounds/scripts/get-fzf.sh
+++ b/playgrounds/scripts/get-fzf.sh
@@ -2,6 +2,6 @@
 set -eu
 
 git clone --depth 1 https://github.com/junegunn/fzf.git $HOME/.fzf
-$HOME/.fzf/install
+$HOME/.fzf/install --no-update-rc
 
 git clone --depth 1 https://github.com/junegunn/fzf.vim.git $HOME/.vim/bundle/fzf.vim


### PR DESCRIPTION
Currently fzf takes over normal completion for (at least) git, because it gets loaded before regular bash completion.

This change defers updating ~/bashrc until other modifications to that file are added
(ie. fzf load disable during install).